### PR TITLE
Implement caffe u-net architecture

### DIFF
--- a/models/unet_caffe/deploy.prototxt
+++ b/models/unet_caffe/deploy.prototxt
@@ -1,0 +1,126 @@
+name: "unet_4level_deploy"
+
+layer { name: "data" type: "Input" top: "data"
+  input_param { shape { dim: 1 dim: 3 dim: 512 dim: 512 } } }
+
+# Encoder level 1 (64)
+layer { name: "enc1_conv1" type: "Convolution" bottom: "data" top: "enc1_conv1"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc1_relu1" type: "ReLU" bottom: "enc1_conv1" top: "enc1_conv1" }
+layer { name: "enc1_conv2" type: "Convolution" bottom: "enc1_conv1" top: "enc1_conv2"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc1_relu2" type: "ReLU" bottom: "enc1_conv2" top: "enc1_conv2" }
+layer { name: "pool1" type: "Pooling" bottom: "enc1_conv2" top: "pool1"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Encoder level 2 (128)
+layer { name: "enc2_conv1" type: "Convolution" bottom: "pool1" top: "enc2_conv1"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc2_relu1" type: "ReLU" bottom: "enc2_conv1" top: "enc2_conv1" }
+layer { name: "enc2_conv2" type: "Convolution" bottom: "enc2_conv1" top: "enc2_conv2"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc2_relu2" type: "ReLU" bottom: "enc2_conv2" top: "enc2_conv2" }
+layer { name: "pool2" type: "Pooling" bottom: "enc2_conv2" top: "pool2"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Encoder level 3 (256)
+layer { name: "enc3_conv1" type: "Convolution" bottom: "pool2" top: "enc3_conv1"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc3_relu1" type: "ReLU" bottom: "enc3_conv1" top: "enc3_conv1" }
+layer { name: "enc3_conv2" type: "Convolution" bottom: "enc3_conv1" top: "enc3_conv2"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc3_relu2" type: "ReLU" bottom: "enc3_conv2" top: "enc3_conv2" }
+layer { name: "pool3" type: "Pooling" bottom: "enc3_conv2" top: "pool3"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Encoder level 4 (512)
+layer { name: "enc4_conv1" type: "Convolution" bottom: "pool3" top: "enc4_conv1"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc4_relu1" type: "ReLU" bottom: "enc4_conv1" top: "enc4_conv1" }
+layer { name: "enc4_conv2" type: "Convolution" bottom: "enc4_conv1" top: "enc4_conv2"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc4_relu2" type: "ReLU" bottom: "enc4_conv2" top: "enc4_conv2" }
+layer { name: "pool4" type: "Pooling" bottom: "enc4_conv2" top: "pool4"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Bottleneck (1024)
+layer { name: "bn_conv1" type: "Convolution" bottom: "pool4" top: "bn_conv1"
+  convolution_param { num_output: 1024 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "bn_relu1" type: "ReLU" bottom: "bn_conv1" top: "bn_conv1" }
+layer { name: "bottleneck" type: "Convolution" bottom: "bn_conv1" top: "bottleneck"
+  convolution_param { num_output: 1024 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "bn_relu2" type: "ReLU" bottom: "bottleneck" top: "bottleneck" }
+
+# Decoder level 4 (up 1024->512)
+layer { name: "up4" type: "Deconvolution" bottom: "bottleneck" top: "up4"
+  convolution_param { num_output: 512 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec4_concat" type: "Concat" bottom: "up4" bottom: "enc4_conv2" top: "dec4_concat" concat_param { axis: 1 } }
+layer { name: "dec4_conv1" type: "Convolution" bottom: "dec4_concat" top: "dec4_conv1"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec4_relu1" type: "ReLU" bottom: "dec4_conv1" top: "dec4_conv1" }
+layer { name: "dec4_conv2" type: "Convolution" bottom: "dec4_conv1" top: "dec4_conv2"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec4_relu2" type: "ReLU" bottom: "dec4_conv2" top: "dec4_conv2" }
+
+# Decoder level 3 (up 512->256)
+layer { name: "up3" type: "Deconvolution" bottom: "dec4_conv2" top: "up3"
+  convolution_param { num_output: 256 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec3_concat" type: "Concat" bottom: "up3" bottom: "enc3_conv2" top: "dec3_concat" concat_param { axis: 1 } }
+layer { name: "dec3_conv1" type: "Convolution" bottom: "dec3_concat" top: "dec3_conv1"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec3_relu1" type: "ReLU" bottom: "dec3_conv1" top: "dec3_conv1" }
+layer { name: "dec3_conv2" type: "Convolution" bottom: "dec3_conv1" top: "dec3_conv2"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec3_relu2" type: "ReLU" bottom: "dec3_conv2" top: "dec3_conv2" }
+
+# Decoder level 2 (up 256->128)
+layer { name: "up2" type: "Deconvolution" bottom: "dec3_conv2" top: "up2"
+  convolution_param { num_output: 128 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec2_concat" type: "Concat" bottom: "up2" bottom: "enc2_conv2" top: "dec2_concat" concat_param { axis: 1 } }
+layer { name: "dec2_conv1" type: "Convolution" bottom: "dec2_concat" top: "dec2_conv1"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec2_relu1" type: "ReLU" bottom: "dec2_conv1" top: "dec2_conv1" }
+layer { name: "dec2_conv2" type: "Convolution" bottom: "dec2_conv1" top: "dec2_conv2"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec2_relu2" type: "ReLU" bottom: "dec2_conv2" top: "dec2_conv2" }
+
+# Decoder level 1 (up 128->64)
+layer { name: "up1" type: "Deconvolution" bottom: "dec2_conv2" top: "up1"
+  convolution_param { num_output: 64 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec1_concat" type: "Concat" bottom: "up1" bottom: "enc1_conv2" top: "dec1_concat" concat_param { axis: 1 } }
+layer { name: "dec1_conv1" type: "Convolution" bottom: "dec1_concat" top: "dec1_conv1"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec1_relu1" type: "ReLU" bottom: "dec1_conv1" top: "dec1_conv1" }
+layer { name: "dec1_conv2" type: "Convolution" bottom: "dec1_conv1" top: "dec1_conv2"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec1_relu2" type: "ReLU" bottom: "dec1_conv2" top: "dec1_conv2" }
+
+# Classifier + Softmax/ArgMax
+layer { name: "score" type: "Convolution" bottom: "dec1_conv2" top: "score"
+  convolution_param { num_output: 2 kernel_size: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "prob" type: "Softmax" bottom: "score" top: "prob" }
+layer { name: "mask" type: "ArgMax" bottom: "score" top: "mask"
+  argmax_param { out_max_val: false top_k: 1 } }

--- a/models/unet_caffe/solver.prototxt
+++ b/models/unet_caffe/solver.prototxt
@@ -1,0 +1,15 @@
+net: "models/unet_caffe/train.prototxt"
+base_lr: 0.001
+lr_policy: "poly"
+power: 0.9
+momentum: 0.9
+weight_decay: 0.0005
+max_iter: 40000
+iter_size: 1
+display: 20
+average_loss: 20
+test_interval: 1000
+test_iter: 100
+snapshot: 5000
+snapshot_prefix: "models/unet_caffe/snapshots/unet"
+solver_mode: GPU

--- a/models/unet_caffe/train.prototxt
+++ b/models/unet_caffe/train.prototxt
@@ -1,0 +1,128 @@
+name: "unet_4level_train"
+
+layer { name: "data" type: "Input" top: "data"
+  input_param { shape { dim: 1 dim: 3 dim: 512 dim: 512 } } }
+layer { name: "label" type: "Input" top: "label"
+  input_param { shape { dim: 1 dim: 1 dim: 512 dim: 512 } } }
+
+# Encoder level 1 (64)
+layer { name: "enc1_conv1" type: "Convolution" bottom: "data" top: "enc1_conv1"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc1_relu1" type: "ReLU" bottom: "enc1_conv1" top: "enc1_conv1" }
+layer { name: "enc1_conv2" type: "Convolution" bottom: "enc1_conv1" top: "enc1_conv2"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc1_relu2" type: "ReLU" bottom: "enc1_conv2" top: "enc1_conv2" }
+layer { name: "pool1" type: "Pooling" bottom: "enc1_conv2" top: "pool1"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Encoder level 2 (128)
+layer { name: "enc2_conv1" type: "Convolution" bottom: "pool1" top: "enc2_conv1"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc2_relu1" type: "ReLU" bottom: "enc2_conv1" top: "enc2_conv1" }
+layer { name: "enc2_conv2" type: "Convolution" bottom: "enc2_conv1" top: "enc2_conv2"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc2_relu2" type: "ReLU" bottom: "enc2_conv2" top: "enc2_conv2" }
+layer { name: "pool2" type: "Pooling" bottom: "enc2_conv2" top: "pool2"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Encoder level 3 (256)
+layer { name: "enc3_conv1" type: "Convolution" bottom: "pool2" top: "enc3_conv1"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc3_relu1" type: "ReLU" bottom: "enc3_conv1" top: "enc3_conv1" }
+layer { name: "enc3_conv2" type: "Convolution" bottom: "enc3_conv1" top: "enc3_conv2"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc3_relu2" type: "ReLU" bottom: "enc3_conv2" top: "enc3_conv2" }
+layer { name: "pool3" type: "Pooling" bottom: "enc3_conv2" top: "pool3"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Encoder level 4 (512)
+layer { name: "enc4_conv1" type: "Convolution" bottom: "pool3" top: "enc4_conv1"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc4_relu1" type: "ReLU" bottom: "enc4_conv1" top: "enc4_conv1" }
+layer { name: "enc4_conv2" type: "Convolution" bottom: "enc4_conv1" top: "enc4_conv2"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "enc4_relu2" type: "ReLU" bottom: "enc4_conv2" top: "enc4_conv2" }
+layer { name: "pool4" type: "Pooling" bottom: "enc4_conv2" top: "pool4"
+  pooling_param { pool: MAX kernel_size: 2 stride: 2 } }
+
+# Bottleneck (1024)
+layer { name: "bn_conv1" type: "Convolution" bottom: "pool4" top: "bn_conv1"
+  convolution_param { num_output: 1024 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "bn_relu1" type: "ReLU" bottom: "bn_conv1" top: "bn_conv1" }
+layer { name: "bottleneck" type: "Convolution" bottom: "bn_conv1" top: "bottleneck"
+  convolution_param { num_output: 1024 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "bn_relu2" type: "ReLU" bottom: "bottleneck" top: "bottleneck" }
+
+# Decoder level 4 (up 1024->512)
+layer { name: "up4" type: "Deconvolution" bottom: "bottleneck" top: "up4"
+  convolution_param { num_output: 512 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec4_concat" type: "Concat" bottom: "up4" bottom: "enc4_conv2" top: "dec4_concat" concat_param { axis: 1 } }
+layer { name: "dec4_conv1" type: "Convolution" bottom: "dec4_concat" top: "dec4_conv1"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec4_relu1" type: "ReLU" bottom: "dec4_conv1" top: "dec4_conv1" }
+layer { name: "dec4_conv2" type: "Convolution" bottom: "dec4_conv1" top: "dec4_conv2"
+  convolution_param { num_output: 512 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec4_relu2" type: "ReLU" bottom: "dec4_conv2" top: "dec4_conv2" }
+
+# Decoder level 3 (up 512->256)
+layer { name: "up3" type: "Deconvolution" bottom: "dec4_conv2" top: "up3"
+  convolution_param { num_output: 256 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec3_concat" type: "Concat" bottom: "up3" bottom: "enc3_conv2" top: "dec3_concat" concat_param { axis: 1 } }
+layer { name: "dec3_conv1" type: "Convolution" bottom: "dec3_concat" top: "dec3_conv1"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec3_relu1" type: "ReLU" bottom: "dec3_conv1" top: "dec3_conv1" }
+layer { name: "dec3_conv2" type: "Convolution" bottom: "dec3_conv1" top: "dec3_conv2"
+  convolution_param { num_output: 256 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec3_relu2" type: "ReLU" bottom: "dec3_conv2" top: "dec3_conv2" }
+
+# Decoder level 2 (up 256->128)
+layer { name: "up2" type: "Deconvolution" bottom: "dec3_conv2" top: "up2"
+  convolution_param { num_output: 128 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec2_concat" type: "Concat" bottom: "up2" bottom: "enc2_conv2" top: "dec2_concat" concat_param { axis: 1 } }
+layer { name: "dec2_conv1" type: "Convolution" bottom: "dec2_concat" top: "dec2_conv1"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec2_relu1" type: "ReLU" bottom: "dec2_conv1" top: "dec2_conv1" }
+layer { name: "dec2_conv2" type: "Convolution" bottom: "dec2_conv1" top: "dec2_conv2"
+  convolution_param { num_output: 128 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec2_relu2" type: "ReLU" bottom: "dec2_conv2" top: "dec2_conv2" }
+
+# Decoder level 1 (up 128->64)
+layer { name: "up1" type: "Deconvolution" bottom: "dec2_conv2" top: "up1"
+  convolution_param { num_output: 64 kernel_size: 2 stride: 2
+    weight_filler { type: "bilinear" } bias_term: false } }
+layer { name: "dec1_concat" type: "Concat" bottom: "up1" bottom: "enc1_conv2" top: "dec1_concat" concat_param { axis: 1 } }
+layer { name: "dec1_conv1" type: "Convolution" bottom: "dec1_concat" top: "dec1_conv1"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec1_relu1" type: "ReLU" bottom: "dec1_conv1" top: "dec1_conv1" }
+layer { name: "dec1_conv2" type: "Convolution" bottom: "dec1_conv1" top: "dec1_conv2"
+  convolution_param { num_output: 64 kernel_size: 3 pad: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "dec1_relu2" type: "ReLU" bottom: "dec1_conv2" top: "dec1_conv2" }
+
+# Classifier + Loss
+layer { name: "score" type: "Convolution" bottom: "dec1_conv2" top: "score"
+  convolution_param { num_output: 2 kernel_size: 1
+    weight_filler { type: "xavier" } bias_filler { type: "constant" value: 0 } } }
+layer { name: "loss" type: "SoftmaxWithLoss" bottom: "score" bottom: "label" top: "loss"
+  loss_param { ignore_label: 255 } }
+layer { name: "prob" type: "Softmax" bottom: "score" top: "prob" }


### PR DESCRIPTION
Add Caffe prototxt files for a 4-level U-Net architecture to implement semantic segmentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-397cb561-e498-443a-90d8-0859edf12ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-397cb561-e498-443a-90d8-0859edf12ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

